### PR TITLE
Changed API from i32 to u32

### DIFF
--- a/src/globals.rs
+++ b/src/globals.rs
@@ -16,20 +16,20 @@ lazy_static! {
 // Invokable functions in the ribosome
 // WARNING Names must be in sync with ZomeAPIFunction in holochain-rust
 extern {
-  pub(crate) fn hc_property(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_make_hash(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_debug(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_call(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_sign(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_verify_signature(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_commit_entry(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_update_entry(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_remove_entry(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_get_entry(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_link_entries(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_get_links(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_query(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_send(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_start_bundle(encoded_allocation_of_input: i32) -> i32;
-  pub(crate) fn hc_close_bundle(encoded_allocation_of_input: i32) -> i32;
+  pub(crate) fn hc_property(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_make_hash(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_debug(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_call(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_sign(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_verify_signature(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_commit_entry(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_update_entry(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_remove_entry(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_get_entry(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_link_entries(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_get_links(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_query(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_send(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_start_bundle(encoded_allocation_of_input: u32) -> u32;
+  pub(crate) fn hc_close_bundle(encoded_allocation_of_input: u32) -> u32;
 }

--- a/src/init_globals.rs
+++ b/src/init_globals.rs
@@ -3,7 +3,7 @@
 use holochain_wasm_utils::try_deserialize_allocation;
 
 extern {
-  fn hc_init_globals(encoded_allocation_of_input: i32) -> i32;
+  fn hc_init_globals(encoded_allocation_of_input: u32) -> u32;
 }
 
 // WARNING must be in sync with InitGlobalsOutput in core
@@ -21,7 +21,7 @@ pub(crate) struct AppGlobals {
 // Retrieve all the public global values from the ribosome
 pub(crate) fn init_globals() -> AppGlobals {
   // Call WASMI-able init_globals
-  let encoded_allocation_of_result : i32;
+  let encoded_allocation_of_result : u32;
   unsafe {
     encoded_allocation_of_result = hc_init_globals(0);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub fn debug(msg: &str) {
   let mut mem_stack: SinglePageStack;
   unsafe { mem_stack = g_mem_stack.unwrap(); }
   let allocation_of_input =  serialize(&mut mem_stack, msg);
-  unsafe { hc_debug(allocation_of_input.encode() as i32); }
+  unsafe { hc_debug(allocation_of_input.encode()); }
   mem_stack.deallocate(allocation_of_input)
     .expect("should be able to deallocate input that has been allocated on memory stack");
 }

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -6,9 +6,9 @@ use holochain_wasm_utils::*;
 use hdk::globals::g_mem_stack;
 
 #[no_mangle]
-pub extern "C" fn check_global_dispatch(encoded_allocation_of_input : i32) -> i32 {
+pub extern "C" fn check_global_dispatch(encoded_allocation_of_input : u32) -> u32 {
   unsafe {
-    g_mem_stack = Some(SinglePageStack::new_from_encoded(encoded_allocation_of_input as u32));
+    g_mem_stack = Some(SinglePageStack::new_from_encoded(encoded_allocation_of_input));
   }
     hdk::debug(&hdk::APP_NAME);
     hdk::debug(&hdk::APP_DNA_HASH);


### PR DESCRIPTION
I thought i32 was required because thats the only type in wasmi but it works with u32. which is what we want.