### PR TITLE
Validation Macro [ENTRY]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ serde_json = "1.0"
 bitflags = "1.0"
 lazy_static = "1.1.0"
 holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
-either = "1.5.0"
 
 [dev-dependencies]
 test_utils = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0"
 bitflags = "1.0"
 lazy_static = "1.1.0"
 holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }
+either = "1.5.0"
 
 [dev-dependencies]
 test_utils = { git = "https://github.com/holochain/holochain-rust" , branch = "develop" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ use holochain_wasm_utils::{
 };
 use either::Either;
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ValidationData;
+pub use holochain_wasm_utils::validation::*;
+
 pub type HashString = String;
 
 //--------------------------------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,14 @@ pub mod macros;
 
 use self::RibosomeError::*;
 use globals::*;
-use holochain_wasm_utils::{memory_serialization::*, memory_allocation::*};
+use holochain_wasm_utils::{
+    memory_serialization::*, memory_allocation::*,
+    validation::*
+};
 use either::Either;
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ValidationData;
 pub type HashString = String;
 
 //--------------------------------------------------------------------------------------------------
@@ -162,64 +167,6 @@ mod bundle_cancel {
 pub enum BundleOnClose {
     Commit,
     Discard,
-}
-
-pub type Address = String;
-pub type EntryType = String;
-
-#[derive(Serialize, Deserialize)]
-pub struct ChainHeader {
-    /// the type of this entry
-    /// system types may have associated "subconscious" behavior
-    entry_type: EntryType,
-    /// ISO8601 time stamp
-    timestamp: String,
-    /// Key to the immediately preceding header. Only the genesis Pair can have None as valid
-    link: Option<Address>,
-    /// Key to the entry of this header
-    entry_address: Address,
-    /// agent's cryptographic signature of the entry
-    entry_signature: String,
-    /// Key to the most recent header of the same type, None is valid only for the first of that type
-    link_same_type: Option<Address>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ValidationData {
-    pub chain_header: Option<ChainHeader>,
-    pub sources : Vec<HashString>,
-    pub source_chain_entries : Option<Vec<serde_json::Value>>,
-    pub source_chain_headers : Option<Vec<ChainHeader>>,
-    pub custom : Option<serde_json::Value>,
-    pub lifecycle : HcEntryLifecycle,
-    pub action : HcEntryAction,
- }
-
-#[derive(Serialize, Deserialize)]
-pub enum HcEntryLifecycle {
-    Chain,
-    Dht,
-    Meta,
- }
-
-#[derive(Serialize, Deserialize)]
-pub enum HcEntryAction {
-    Commit,
-    Modify,
-    Delete,
- }
-
-#[derive(Serialize, Deserialize)]
-pub enum HcLinkAction {
-    Commit,
-    Delete,
- }
-
- #[derive(Serialize, Deserialize)]
- #[serde(remote = "Either")]
-pub enum EitherDef<L, R> {
-    Left(L),
-    Right(R),
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,21 +164,35 @@ pub enum BundleOnClose {
     Discard,
 }
 
+pub type Address = String;
+pub type EntryType = String;
+
 #[derive(Serialize, Deserialize)]
 pub struct ChainHeader {
-
+    /// the type of this entry
+    /// system types may have associated "subconscious" behavior
+    entry_type: EntryType,
+    /// ISO8601 time stamp
+    timestamp: String,
+    /// Key to the immediately preceding header. Only the genesis Pair can have None as valid
+    link: Option<Address>,
+    /// Key to the entry of this header
+    entry_address: Address,
+    /// agent's cryptographic signature of the entry
+    entry_signature: String,
+    /// Key to the most recent header of the same type, None is valid only for the first of that type
+    link_same_type: Option<Address>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct ValidationData {
-    chainHeader: ChainHeader,
-    sources : Vec<HashString>,
-    sourceChainEntries : Option<Vec<serde_json::Value>>,
-    sourceChainHeaders : Option<Vec<ChainHeader>>,
-    custom : Option<serde_json::Value>,
-    lifecycle : HcEntryLifecycle,
-    #[serde(with = "EitherDef")]
-    action : Either<HcEntryAction, HcLinkAction>,
+    pub chain_header: Option<ChainHeader>,
+    pub sources : Vec<HashString>,
+    pub source_chain_entries : Option<Vec<serde_json::Value>>,
+    pub source_chain_headers : Option<Vec<ChainHeader>>,
+    pub custom : Option<serde_json::Value>,
+    pub lifecycle : HcEntryLifecycle,
+    pub action : HcEntryAction,
  }
 
 #[derive(Serialize, Deserialize)]
@@ -276,7 +290,7 @@ pub fn commit_entry(
     #[derive(Serialize, Default)]
     struct CommitInputStruct {
         entry_type_name: String,
-        entry_content: String,
+        entry_content: serde_json::Value,
     }
 
     #[derive(Deserialize, Serialize, Default)]
@@ -292,7 +306,7 @@ pub fn commit_entry(
     // Put args in struct and serialize into memory
     let input = CommitInputStruct {
         entry_type_name: entry_type_name.to_string(),
-        entry_content: entry_content.to_string(),
+        entry_content: entry_content,
     };
     let allocation_of_input = serialize(&mut mem_stack, input);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
 pub extern crate holochain_wasm_utils;
-extern crate either;
 
 pub mod globals;
 pub mod init_globals;
@@ -23,8 +22,6 @@ use holochain_wasm_utils::{
     memory_serialization::*, memory_allocation::*,
     validation::*
 };
-use either::Either;
-
 pub use holochain_wasm_utils::validation::*;
 
 pub type HashString = String;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
 pub extern crate holochain_wasm_utils;
+extern crate either;
 
 pub mod globals;
 pub mod init_globals;
@@ -19,6 +20,7 @@ pub mod macros;
 use self::RibosomeError::*;
 use globals::*;
 use holochain_wasm_utils::{memory_serialization::*, memory_allocation::*};
+use either::Either;
 
 pub type HashString = String;
 
@@ -160,6 +162,50 @@ mod bundle_cancel {
 pub enum BundleOnClose {
     Commit,
     Discard,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ChainHeader {
+
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ValidationData {
+    chainHeader: ChainHeader,
+    sources : Vec<HashString>,
+    sourceChainEntries : Option<Vec<serde_json::Value>>,
+    sourceChainHeaders : Option<Vec<ChainHeader>>,
+    custom : Option<serde_json::Value>,
+    lifecycle : HcEntryLifecycle,
+    #[serde(with = "EitherDef")]
+    action : Either<HcEntryAction, HcLinkAction>,
+ }
+
+#[derive(Serialize, Deserialize)]
+pub enum HcEntryLifecycle {
+    Chain,
+    Dht,
+    Meta,
+ }
+
+#[derive(Serialize, Deserialize)]
+pub enum HcEntryAction {
+    Commit,
+    Modify,
+    Delete,
+ }
+
+#[derive(Serialize, Deserialize)]
+pub enum HcLinkAction {
+    Commit,
+    Delete,
+ }
+
+ #[derive(Serialize, Deserialize)]
+ #[serde(remote = "Either")]
+pub enum EitherDef<L, R> {
+    Left(L),
+    Right(R),
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,24 @@ pub use holochain_wasm_utils::validation::*;
 
 pub type HashString = String;
 
+pub fn init_memory_stack(encoded_allocation_of_input: u32) {
+    // Actual program
+    // Init memory stack
+    unsafe {
+        G_MEM_STACK =
+            Some(SinglePageStack::from_encoded(encoded_allocation_of_input));
+    }
+}
+
+pub fn serialize_wasm_output<T: serde::Serialize>(output: T) -> u32
+{
+    // Serialize output in WASM memory
+    unsafe {
+        return serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), output) as u32;
+    }
+}
+
+
 //--------------------------------------------------------------------------------------------------
 // APP GLOBAL VARIABLES
 //--------------------------------------------------------------------------------------------------

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,23 +50,23 @@ macro_rules! zome_functions {
             #[no_mangle]
             pub extern "C" fn $func_name(encoded_allocation_of_input: u32) -> u32 {
 
+                ::hdk::init_memory_stack(encoded_allocation_of_input);
+
                 // Macro'd InputStruct
                 #[derive(Deserialize)]
                 struct InputStruct {
                     $($param : $param_type),*
                 }
 
+                // Deserialize input
+                let maybe_input = try_deserialize_arguments!(encoded_allocation_of_input);
+                let input: InputStruct = maybe_input.unwrap();
+
                 // Macro'd function body
                 fn execute(params: InputStruct) -> impl ::serde::Serialize {
                     let InputStruct { $($param),* } = params;
                     $main_block
                 }
-
-                ::hdk::init_memory_stack(encoded_allocation_of_input);
-
-                // Deserialize input
-                let maybe_input = try_deserialize_arguments!(encoded_allocation_of_input);
-                let input: InputStruct = maybe_input.unwrap();
 
                 // Execute inner function
                 let output_obj = execute(input);
@@ -91,6 +91,8 @@ macro_rules! validations {
             #[no_mangle]
             pub extern "C" fn $func_name(encoded_allocation_of_input: u32) -> u32 {
 
+                ::hdk::init_memory_stack(encoded_allocation_of_input);
+
                 // Macro'd InputStruct
                 #[derive(Deserialize)]
                 struct InputStruct {
@@ -104,14 +106,6 @@ macro_rules! validations {
                     ctx : ::hdk::ValidationData,
                 }
 
-                // Macro'd function body
-                fn execute(params: InputStruct) -> Result<(), String> {
-                    let InputStruct { $entry, $ctx } = params;
-                    $main_block
-                }
-
-                ::hdk::init_memory_stack(encoded_allocation_of_input);
-
                 // Deserialize input
                 let maybe_input = try_deserialize_arguments!(encoded_allocation_of_input);
                 let input_generic: InputStructGeneric = maybe_input.unwrap();
@@ -120,7 +114,12 @@ macro_rules! validations {
                     $ctx: input_generic.ctx,
                 };
 
-
+                // Macro'd function body
+                fn execute(params: InputStruct) -> Result<(), String> {
+                    let InputStruct { $entry, $ctx } = params;
+                    $main_block
+                }
+                
                 // Execute inner function
                 let output_result = execute(input);
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -48,12 +48,7 @@ macro_rules! zome_functions {
                     $main_block
                 }
 
-                // Actual program
-                // Init memory stack
-                unsafe {
-                    ::hdk::globals::G_MEM_STACK =
-                        Some(::holochain_wasm_utils::memory_allocation::SinglePageStack::from_encoded(encoded_allocation_of_input));
-                }
+                ::hdk::init_memory_stack(encoded_allocation_of_input);
 
                 // Deserialize input
                 let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
@@ -65,10 +60,7 @@ macro_rules! zome_functions {
                 // Execute inner function
                 let output_obj = execute(input);
 
-                // Serialize output in WASM memory
-                unsafe {
-                    return ::holochain_wasm_utils::memory_serialization::serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), output_obj) as u32;
-                }
+                ::hdk::serialize_wasm_output(output_obj)
             }
         )+
     );
@@ -107,12 +99,7 @@ macro_rules! validations {
                     $main_block
                 }
 
-                // Actual program
-                // Init memory stack
-                unsafe {
-                    ::hdk::globals::G_MEM_STACK =
-                        Some(::holochain_wasm_utils::memory_allocation::SinglePageStack::from_encoded(encoded_allocation_of_input));
-                }
+                ::hdk::init_memory_stack(encoded_allocation_of_input);
 
                 // Deserialize input
                 let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
@@ -130,10 +117,7 @@ macro_rules! validations {
                 // Execute inner function
                 let output_result = execute(input);
 
-                // Serialize output in WASM memory
-                unsafe {
-                    return ::holochain_wasm_utils::memory_serialization::serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), output_result) as u32;
-                }
+                ::hdk::serialize_wasm_output(output_result)
             }
         )+
     );

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -118,7 +118,7 @@ macro_rules! validations {
                 let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
                 if let Err(err) = maybe_input {
                     hdk::debug(&format!("Error deserializing: {}", err));
-                    return ::holochain_wasm_utils::error::RibosomeReturnCode::ArgumentDeserializationFailed as u32;
+                    return ::holochain_wasm_utils::error::RibosomeErrorCode::ArgumentDeserializationFailed as u32;
                 }
                 let input_generic: InputStructGeneric = maybe_input.unwrap();
                 let input = InputStruct {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,3 +73,56 @@ macro_rules! zome_functions {
         )+
     );
 }
+
+
+#[macro_export]
+macro_rules! validations {
+    (
+        $([ENTRY] $func_name:ident {
+            [$package:path]
+            | $entry:ident : $entry_type:ty, $ctx:ident : hdk::ValidationData | $main_block:expr
+        })+
+    ) => (
+
+        $(
+            #[no_mangle]
+            pub extern "C" fn $func_name(encoded_allocation_of_input: u32) -> u32 {
+
+                // Macro'd InputStruct
+                #[derive(Deserialize)]
+                struct InputStruct {
+                    $entry : $entry_type,
+                    $ctx : ::hdk::ValidationData,
+                }
+
+                // Macro'd function body
+                fn execute(params: InputStruct) -> Result<(), String> {
+                    let InputStruct { $entry, $ctx } = params;
+                    $main_block
+                }
+
+                // Actual program
+                // Init memory stack
+                unsafe {
+                    ::hdk::globals::G_MEM_STACK =
+                        Some(::holochain_wasm_utils::memory_allocation::SinglePageStack::from_encoded(encoded_allocation_of_input));
+                }
+
+                // Deserialize input
+                let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
+                if let Err(_) = maybe_input {
+                    return ::holochain_wasm_utils::error::RibosomeReturnCode::ArgumentDeserializationFailed as u32;
+                }
+                let input: InputStruct = maybe_input.unwrap();
+
+                // Execute inner function
+                let output_result = execute(input);
+
+                // Serialize output in WASM memory
+                unsafe {
+                    return ::holochain_wasm_utils::memory_serialization::serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), output_result) as u32;
+                }
+            }
+        )+
+    );
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,17 @@
+#[macro_export]
+macro_rules! try_deserialize_arguments {
+    ($encoded_allocation_of_input:ident) => (
+        {
+            let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation($encoded_allocation_of_input);
+            if let Err(_) = maybe_input {
+                return ::holochain_wasm_utils::error::RibosomeErrorCode::ArgumentDeserializationFailed as u32;
+            }
+            maybe_input
+        }
+    );
+}
+
+
 /// A macro for easily writing zome functions
 ///
 /// # Examples
@@ -51,10 +65,7 @@ macro_rules! zome_functions {
                 ::hdk::init_memory_stack(encoded_allocation_of_input);
 
                 // Deserialize input
-                let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
-                if let Err(_) = maybe_input {
-                    return ::holochain_wasm_utils::error::RibosomeErrorCode::ArgumentDeserializationFailed as u32;
-                }
+                let maybe_input = try_deserialize_arguments!(encoded_allocation_of_input);
                 let input: InputStruct = maybe_input.unwrap();
 
                 // Execute inner function
@@ -102,11 +113,7 @@ macro_rules! validations {
                 ::hdk::init_memory_stack(encoded_allocation_of_input);
 
                 // Deserialize input
-                let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
-                if let Err(err) = maybe_input {
-                    hdk::debug(&format!("Error deserializing: {}", err));
-                    return ::holochain_wasm_utils::error::RibosomeErrorCode::ArgumentDeserializationFailed as u32;
-                }
+                let maybe_input = try_deserialize_arguments!(encoded_allocation_of_input);
                 let input_generic: InputStructGeneric = maybe_input.unwrap();
                 let input = InputStruct {
                     $entry: input_generic.entry,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,6 +95,12 @@ macro_rules! validations {
                     $ctx : ::hdk::ValidationData,
                 }
 
+                #[derive(Deserialize)]
+                struct InputStructGeneric {
+                    entry : $entry_type,
+                    ctx : ::hdk::ValidationData,
+                }
+
                 // Macro'd function body
                 fn execute(params: InputStruct) -> Result<(), String> {
                     let InputStruct { $entry, $ctx } = params;
@@ -110,10 +116,16 @@ macro_rules! validations {
 
                 // Deserialize input
                 let maybe_input = ::holochain_wasm_utils::memory_serialization::try_deserialize_allocation(encoded_allocation_of_input);
-                if let Err(_) = maybe_input {
+                if let Err(err) = maybe_input {
+                    hdk::debug(&format!("Error deserializing: {}", err));
                     return ::holochain_wasm_utils::error::RibosomeReturnCode::ArgumentDeserializationFailed as u32;
                 }
-                let input: InputStruct = maybe_input.unwrap();
+                let input_generic: InputStructGeneric = maybe_input.unwrap();
+                let input = InputStruct {
+                    $entry: input_generic.entry,
+                    $ctx: input_generic.ctx,
+                };
+
 
                 // Execute inner function
                 let output_result = execute(input);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -94,3 +94,18 @@ fn can_round_trip() {
 
     println!("{:?}", *test_logger);
 }
+
+#[test]
+fn can_invalidate_invalid_commit() {
+    let (mut hc, _) = start_holochain_instance();
+    // Call the exposed wasm function that calls the Commit API function
+    let result = hc.call(
+        "test_zome",
+        "test_cap",
+        "check_commit_entry_macro",
+        r#"{ "entry_type_name": "testEntryType", "entry_content": "FAIL" }"#,
+    );
+    println!("\t result = {:?}", result);
+    assert!(result.is_err(), "\t result = {:?}", result);
+    assert_eq!("FAIL content is not allowed", result.err().unwrap().to_string());
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -103,7 +103,7 @@ fn can_invalidate_invalid_commit() {
         "test_zome",
         "test_cap",
         "check_commit_entry_macro",
-        r#"{ "entry_type_name": "testEntryType", "entry_content": "FAIL" }"#,
+        r#"{ "entry_type_name": "testEntryType", "entry_content": "{\"stuff\": \"FAIL\"}" }"#,
     );
     println!("\t result = {:?}", result);
     assert!(result.is_err(), "\t result = {:?}", result);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,7 +70,7 @@ fn can_commit_entry_macro() {
         "test_zome",
         "test_cap",
         "check_commit_entry_macro",
-        r#"{ "entry_type_name": "typename1", "entry_content": "some content" }"#,
+        r#"{ "entry_type_name": "testEntryType", "entry_content": {\"stuff\": \"non fail\"} }"#,
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -106,6 +106,6 @@ fn can_invalidate_invalid_commit() {
         r#"{ "entry_type_name": "testEntryType", "entry_content": "{\"stuff\": \"FAIL\"}" }"#,
     );
     println!("\t result = {:?}", result);
-    assert!(result.is_err(), "\t result = {:?}", result);
-    assert_eq!("FAIL content is not allowed", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "\t result = {:?}", result);
+    assert_eq!("{\"Err\":\"Call to `hc_commit_entry()` failed: \\\"FAIL content is not allowed\\\"\"}", result.unwrap());
 }

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -19,3 +19,4 @@ hdk = { path = ".." }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+boolinator = "2.4"

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -111,7 +111,7 @@ struct TestEntryType {
 }
 
 validations! {
-    [ENTRY] validate_tweet_response {
+    [ENTRY] validate_testEntryType {
         [hdk::ValidationPackage::Entry]
         |entry: TestEntryType, _ctx: hdk::ValidationData| {
             (entry.entry_content != "FAIL")

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -6,7 +6,9 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
+extern crate boolinator;
 
+use boolinator::Boolinator;
 use hdk::globals::G_MEM_STACK;
 use holochain_wasm_utils::{error::RibosomeReturnCode, memory_serialization::*, memory_allocation::*};
 use hdk::RibosomeError;
@@ -90,7 +92,7 @@ zome_functions! {
 }
 
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct TweetResponse {
     first: String,
     second: String,
@@ -100,5 +102,20 @@ zome_functions! {
     send_tweet: |author: String, content: String| {
 
         TweetResponse { first: author,  second: content}
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct TestEntryType {
+    entry_content: String,
+}
+
+validations! {
+    [ENTRY] validate_tweet_response {
+        [hdk::ValidationPackage::Entry]
+        |entry: TestEntryType, _ctx: hdk::ValidationData| {
+            (entry.entry_content != "FAIL")
+                .ok_or_else(|| "FAIL content is not allowed".to_string())
+        }
     }
 }

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -54,9 +54,11 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
     if let Err(_) = result {
         return RibosomeReturnCode::ArgumentDeserializationFailed as u32;
     }
+
     let input: CommitInputStruct = result.unwrap();
-    let entry_json: serde_json::Value = serde_json::from_str(&input.entry_content).unwrap();
-    let res = hdk::commit_entry(&input.entry_type_name, entry_json);
+    let res = hdk::commit_entry(&input.entry_type_name, json!({
+        "entry_content": &input.entry_content
+    }));
 
    let res_obj = match res {
         Ok(hash_str) => CommitOutputStruct {

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -55,10 +55,8 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
         return RibosomeReturnCode::ArgumentDeserializationFailed as u32;
     }
     let input: CommitInputStruct = result.unwrap();
-
-    let res = hdk::commit_entry(&input.entry_type_name, json!(
-        &input.entry_content
-    ));
+    let entry_json: serde_json::Value = serde_json::from_str(&input.entry_content).unwrap();
+    let res = hdk::commit_entry(&input.entry_type_name, entry_json);
 
    let res_obj = match res {
         Ok(hash_str) => CommitOutputStruct {
@@ -107,14 +105,14 @@ zome_functions! {
 
 #[derive(Serialize, Deserialize)]
 struct TestEntryType {
-    entry_content: String,
+    stuff: String,
 }
 
 validations! {
     [ENTRY] validate_testEntryType {
         [hdk::ValidationPackage::Entry]
         |entry: TestEntryType, _ctx: hdk::ValidationData| {
-            (entry.entry_content != "FAIL")
+            (entry.stuff != "FAIL")
                 .ok_or_else(|| "FAIL content is not allowed".to_string())
         }
     }


### PR DESCRIPTION
First half of the macro defined in https://github.com/holochain/app-spec-rust/pull/19.
(no links yet)

Is dependent on https://github.com/holochain/holochain-rust/pull/442.

Makes this work as part of the tests:

```rust
validations! {
    [ENTRY] validate_testEntryType {
        [hdk::ValidationPackage::Entry]
        |entry: TestEntryType, _ctx: hdk::ValidationData| {
            (entry.stuff != "FAIL")
                .ok_or_else(|| "FAIL content is not allowed".to_string())
        }
    }
}
```
