### PR TITLE
Fix commit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub fn serialize_wasm_output<T: serde::Serialize>(output: T) -> u32
 {
     // Serialize output in WASM memory
     unsafe {
-        return serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), output) as u32;
+        return serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), output) as u32
     }
 }
 
@@ -85,6 +85,7 @@ const VERSION: u16 = 1;
 const VERSION_STR: &'static str = "1";
 
 // HC.HashNotFound
+#[derive(Debug)]
 pub enum RibosomeError {
     RibosomeFailed(String),
     FunctionNotImplemented,
@@ -257,12 +258,12 @@ pub fn commit_entry(
     #[derive(Serialize, Default)]
     struct CommitInputStruct {
         entry_type_name: String,
-        entry_content: serde_json::Value,
+        entry_content: String,
     }
 
     #[derive(Deserialize, Serialize, Default)]
     struct CommitOutputStruct {
-        hash: String,
+        address: String,
     }
 
     let mut mem_stack: SinglePageStack;
@@ -273,7 +274,7 @@ pub fn commit_entry(
     // Put args in struct and serialize into memory
     let input = CommitInputStruct {
         entry_type_name: entry_type_name.to_string(),
-        entry_content: entry_content,
+        entry_content: entry_content.to_string(),
     };
     let maybe_allocation_of_input = serialize(&mut mem_stack, input);
     if let Err(err_code) = maybe_allocation_of_input {
@@ -299,7 +300,7 @@ pub fn commit_entry(
         .expect("deallocate failed");
 
     // Return hash
-    Ok(output.hash.to_string())
+    Ok(output.address.to_string())
 }
 
 /// FIXME DOC

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -119,11 +119,13 @@ macro_rules! validations {
                     let InputStruct { $entry, $ctx } = params;
                     $main_block
                 }
-                
-                // Execute inner function
-                let output_result = execute(input);
 
-                ::hdk::serialize_wasm_output(output_result)
+                // Execute inner function
+                let validation_result = execute(input);
+                match validation_result {
+                    Ok(()) => 0,
+                    Err(fail_string) => ::hdk::serialize_wasm_output(fail_string),
+                }
             }
         )+
     );

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -110,5 +110,5 @@ fn can_invalidate_invalid_commit() {
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!("{\"Err\":\"Call to `hc_commit_entry()` failed: \\\"FAIL content is not allowed\\\"\"}", result.unwrap());
+    assert_eq!("{\"error\":\"Call to `hc_commit_entry()` failed: \\\"FAIL content is not allowed\\\"\"}", result.unwrap());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -55,10 +55,12 @@ fn can_commit_entry() {
         "test_zome",
         "test_cap",
         "check_commit_entry",
-        r#"{ "entry_type_name": "typename1", "entry_content": "some content" }"#,
+        r#"{ "entry_type_name": "testEntryType", "entry_content": "{\"stuff\": \"non fail\"}" }"#,
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "result = {:?}", result);
+    assert_eq!(result.unwrap(),r#"{"address":"QmYURqXPNfifiBhFcoQ66SazMwnjDsRNCM1RhJte3jNSBT"}"#);
+
 }
 
 #[test]
@@ -69,10 +71,12 @@ fn can_commit_entry_macro() {
         "test_zome",
         "test_cap",
         "check_commit_entry_macro",
-        r#"{ "entry_type_name": "testEntryType", "entry_content": {\"stuff\": \"non fail\"} }"#,
+        r#"{ "entry_type_name": "testEntryType", "entry_content": "{\"stuff\": \"non fail\"}" }"#,
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);
+    assert_eq!(result.unwrap(),r#"{"address":"QmYURqXPNfifiBhFcoQ66SazMwnjDsRNCM1RhJte3jNSBT"}"#);
+
 }
 
 #[test]


### PR DESCRIPTION
The structs that get passed over to the native side diverged from what is in holochain-core. (CommitInputStruct, CommitOutputStruct). These should go into core-types soon so we can use the exact same code here..

We have to deserialize the json string that is passed into the test zome functions from the tests in order to pass a serde_json::Value into hdk::commit_entry that has the correct contets (without double/tripple escapes). Fixed that.

Also had to fix the return values of the validation macro to make it work in the Ok(()) case. Failure was tested and did work, but the Ok case not ;) which we need for commit.