### PR TITLE
Use types from wasm_utils for de-/serialization of API args/results

### DIFF
--- a/src/init_globals.rs
+++ b/src/init_globals.rs
@@ -1,6 +1,9 @@
 //! File for holding the internal/private zome api function `init_globals`
 
-use holochain_wasm_utils::memory_serialization::try_deserialize_allocation;
+use holochain_wasm_utils::{
+    holochain_core_types::hash::HashString,
+    memory_serialization::try_deserialize_allocation,
+};
 
 extern "C" {
     fn hc_init_globals(encoded_allocation_of_input: u32) -> u32;
@@ -10,11 +13,11 @@ extern "C" {
 #[derive(Deserialize, Clone)]
 pub(crate) struct AppGlobals {
     pub app_name: String,
-    pub app_dna_hash: String,
+    pub app_dna_hash: HashString,
     pub app_agent_id_str: String,
-    pub app_agent_key_hash: String,
-    pub app_agent_initial_hash: String,
-    pub app_agent_latest_hash: String,
+    pub app_agent_key_hash: HashString,
+    pub app_agent_initial_hash: HashString,
+    pub app_agent_latest_hash: HashString,
 }
 
 // HC INIT GLOBALS - Secret Api Function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use self::RibosomeError::*;
 use globals::*;
 use holochain_wasm_utils::{
     api_serialization::{
-        commit::{CommitEntryArgs, CommitOutputStruct},
+        commit::{CommitEntryArgs, CommitEntryResult},
         validation::*,
     },
     memory_serialization::*, memory_allocation::*,
@@ -287,7 +287,7 @@ pub fn commit_entry(
     if let Err(err_str) = result {
         return Err(RibosomeError::RibosomeFailed(err_str));
     }
-    let output: CommitOutputStruct = result.unwrap();
+    let output: CommitEntryResult = result.unwrap();
 
     // Free result & input allocations and all allocations made inside commit()
     mem_stack

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -60,7 +60,7 @@ fn can_commit_entry() {
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "result = {:?}", result);
-    assert_eq!(result.unwrap(),r#"{"address":"QmYURqXPNfifiBhFcoQ66SazMwnjDsRNCM1RhJte3jNSBT"}"#);
+    assert_eq!(result.unwrap(),r#"{"address":"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou"}"#);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn can_commit_entry_macro() {
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(),r#"{"address":"QmYURqXPNfifiBhFcoQ66SazMwnjDsRNCM1RhJte3jNSBT"}"#);
+    assert_eq!(result.unwrap(),r#"{"address":"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou"}"#);
 }
 
 #[test]
@@ -108,13 +108,13 @@ fn can_get_entry() {
         r#"{ "entry_type_name": "testEntryType", "entry_content": "{\"stuff\": \"non fail\"}" }"#,
     );
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(),"{\"address\":\"QmYURqXPNfifiBhFcoQ66SazMwnjDsRNCM1RhJte3jNSBT\"}");
+    assert_eq!(result.unwrap(),"{\"address\":\"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou\"}");
 
     let result = hc.call(
         "test_zome",
         "test_cap",
         "check_get_entry",
-        r#"{"entry_hash":"QmYURqXPNfifiBhFcoQ66SazMwnjDsRNCM1RhJte3jNSBT"}"#,
+        r#"{"entry_hash":"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou"}"#,
     );
     println!("\t can_get_entry result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);
@@ -144,5 +144,5 @@ fn can_invalidate_invalid_commit() {
     );
     println!("\t result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!("{\"error\":\"Call to `hc_commit_entry()` failed: \\\"FAIL content is not allowed\\\"\"}", result.unwrap());
+    assert_eq!("{\"validation failed\":\"\\\"FAIL content is not allowed\\\"\"}", result.unwrap());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,7 +22,7 @@ pub fn create_test_cap_with_fn_names(fn_names: Vec<&str>) -> Capability {
 fn start_holochain_instance() -> (Holochain, Arc<Mutex<TestLogger>>) {
     // Setup the holochain instance
     let wasm =
-        create_wasm_from_file("wasm-test/target/wasm32-unknown-unknown/debug/test_globals.wasm");
+        create_wasm_from_file("wasm-test/target/wasm32-unknown-unknown/release/test_globals.wasm");
     let capabability = create_test_cap_with_fn_names(vec![
         "check_global",
         "check_commit_entry",

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [profile.release]
 panic = "abort"
 lto = true
+opt-level = 'z'
 
 [workspace]
 members = []

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -81,6 +81,7 @@ zome_functions! {
         let res = hdk::commit_entry(&entry_type_name, entry_content.unwrap());
         match res {
             Ok(hash_str) => json!({ "address": hash_str }),
+            Err(RibosomeError::ValidationFailed(msg)) => json!({ "validation failed": msg}),
             Err(RibosomeError::RibosomeFailed(err_str)) => json!({ "error": err_str}),
             Err(_) => unreachable!(),
         }

--- a/wasm-test/src/lib.rs
+++ b/wasm-test/src/lib.rs
@@ -10,7 +10,11 @@ extern crate boolinator;
 
 use boolinator::Boolinator;
 use hdk::globals::G_MEM_STACK;
-use holochain_wasm_utils::{error::RibosomeErrorCode, memory_serialization::*, memory_allocation::*};
+use holochain_wasm_utils::{
+    error::RibosomeErrorCode,
+    holochain_core_types::hash::HashString,
+    memory_serialization::*, memory_allocation::*
+};
 use hdk::RibosomeError;
 
 #[no_mangle]
@@ -20,11 +24,11 @@ pub extern "C" fn check_global(encoded_allocation_of_input: u32) -> u32 {
     }
 
     hdk::debug(&hdk::APP_NAME);
-    hdk::debug(&hdk::APP_DNA_HASH);
+    hdk::debug(&hdk::APP_DNA_HASH.to_string());
     hdk::debug(&hdk::APP_AGENT_ID_STR);
-    hdk::debug(&hdk::APP_AGENT_KEY_HASH);
-    hdk::debug(&hdk::APP_AGENT_INITIAL_HASH);
-    hdk::debug(&hdk::APP_AGENT_LATEST_HASH);
+    hdk::debug(&hdk::APP_AGENT_KEY_HASH.to_string());
+    hdk::debug(&hdk::APP_AGENT_INITIAL_HASH.to_string());
+    hdk::debug(&hdk::APP_AGENT_LATEST_HASH.to_string());
 
     return 0;
 }
@@ -61,7 +65,7 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
     let res = hdk::commit_entry(&input.entry_type_name, entry_content);
 
     let res_obj = match res {
-        Ok(hash_str) => CommitOutputStruct {address: hash_str},
+        Ok(hash_str) => CommitOutputStruct {address: hash_str.to_string()},
         Err(RibosomeError::RibosomeFailed(err_str)) => {
             unsafe {
                 return serialize_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), err_str) as u32;
@@ -87,7 +91,7 @@ zome_functions! {
         }
     }
 
-    check_get_entry: |entry_hash: String| {
+    check_get_entry: |entry_hash: HashString| {
         let res = hdk::get_entry(entry_hash);
         match res {
             Ok(Some(entry)) => {


### PR DESCRIPTION
These changes are according to and dependent on https://github.com/holochain/holochain-rust/pull/479.

* use CommitEntry/GetEntry Args/Results from wasm_utils
* use HashString from `wasm_utils::core_types`
* add `RibosomeError::ValidationFailed(String)` to make `commit_entry`'s usage clearer
* switch wasm-test to release build to prevent super big binaries and initialization timeouts (and thus start using the optimization flag that was set before)